### PR TITLE
Return 404 instead of 500 when data is missing

### DIFF
--- a/neslter/parsing/files.py
+++ b/neslter/parsing/files.py
@@ -10,6 +10,12 @@ ALL = 'all'
 
 FILENAME = 'filename'
 
+
+class DataNotFound(Exception):
+    """Necessary data was not found"""
+    pass
+
+
 class Resolver(object):
     def __init__(self, data_root=None):
         if data_root is None:
@@ -18,7 +24,7 @@ class Resolver(object):
     def raw_directory(self, data_type, cruise=ALL, check_exists=True):
         raw_dir = os.path.join(self.data_root, RAW, cruise, data_type)
         if check_exists and not os.path.exists(raw_dir):
-            raise KeyError('{} directory not found for {}'.format(data_type, cruise))
+            raise DataNotFound('{} directory not found for {}'.format(data_type, cruise))
         return raw_dir
     def raw_file(self, data_type, name=None, check_exists=True, **kw):
         if name is None: # using None so name can be used as a keyword
@@ -26,7 +32,7 @@ class Resolver(object):
         raw_dir = self.raw_directory(data_type, **kw)
         raw_path = os.path.join(raw_dir, name)
         if check_exists and not os.path.exists(raw_path):
-            raise KeyError('file {} not found'.format(raw_path))
+            raise DataNotFound('file {} not found'.format(raw_path))
         return raw_path
     def product_directory(self, data_type, cruise=ALL, makedirs=False):
         proc_dir = os.path.join(self.data_root, PRODUCTS, cruise, data_type)

--- a/nlweb/api/views.py
+++ b/nlweb/api/views.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from config import DATA_ROOT
 
-from neslter.parsing.files import Resolver
+from neslter.parsing.files import Resolver, DataNotFound
 
 from neslter.workflow.ctd import CtdCastWorkflow, CtdBottlesWorkflow, \
         CtdBottleSummaryWorkflow, CtdMetadataWorkflow
@@ -59,13 +59,9 @@ def workflow_response(workflow, extension=None):
     filename = workflow.filename()
     try:
         df = workflow.get_product()
-    except:
-        raise
-    #except KeyError:
-    #    raise Http404('data not found')
-    #except IndexError:
-    #    raise Http404('data not found')
-    return dataframe_response(df, filename, extension)
+        return dataframe_response(df, filename, extension)
+    except DataNotFound as e:
+        raise Http404(str(e))
 
 def cruises(request):
     cruises = Resolver().cruises()


### PR DESCRIPTION
Fixes #57 

* Create new DataNotFound error raised by Resolver
* Reraise as Http404 error in workflow endpoint