### PR TITLE
allow aphanumeric casts

### DIFF
--- a/neslter/parsing/ctd/asc.py
+++ b/neslter/parsing/ctd/asc.py
@@ -62,9 +62,17 @@ def parse_cast(asc_dir, cast=1, delimiter=';'):
         cruise, fcast = pathname2cruise_cast(b)
         if cruise is None or fcast is None: # bad filename, skip
             continue
-        if cast == int(fcast):
-            df = parse_asc(p, delimiter)
-            df.insert(0, 'cast', cast)
-            df.insert(0, 'cruise', cruise)
-            return df
+        try:
+            if int(cast) == int(fcast):
+                df = parse_asc(p, delimiter)
+                df.insert(0, 'cast', cast)
+                df.insert(0, 'cruise', cruise)
+                return df
+        except ValueError:
+            if (cast.lstrip("0") == fcast.lstrip("0")):
+                df = parse_asc(p, delimiter)
+                df.insert(0, 'cast', cast)
+                df.insert(0, 'cruise', cruise)
+                return df
+
     raise KeyError('cast not found: {}'.format(cast))

--- a/neslter/parsing/ctd/btl.py
+++ b/neslter/parsing/ctd/btl.py
@@ -208,7 +208,7 @@ def parse_btl(in_path, add_depth=True, add_lat_lon=True):
     df = clean_column_names(df, {
         'Bottle': 'niskin'
         })
-    df = df.astype({ 'cast': int, 'niskin': int })
+    df = df.astype({ 'niskin': int })
     return df
 
 def compile_btl_files(in_dir, add_depth=True, add_lat_lon=True, summary=False):
@@ -240,7 +240,6 @@ def summarize_compiled_btl_files(compiled_df):
         # sort on those columns even though they're strings
         df = df_with_cast_niskin.copy()
         # the strings are just integers, so we can cast
-        df['cast'] = df['cast'].astype(int)
         df['niskin'] = df['niskin'].astype(int)
         df = df.sort_values(['cruise','cast','niskin'])
         df['cast'] = df['cast'].astype(str)

--- a/neslter/parsing/ctd/common.py
+++ b/neslter/parsing/ctd/common.py
@@ -22,7 +22,8 @@ CRUISE_CAST_PATHNAME_REGEXES = [
     r'(ar22)(\d\d)\.', # Armstrong 22
     r'(ar24)(\d\d\d)\.', # Armstrong 24a
     r'(ar\d\d[a-c]?)(\d\d\d)\.', # Armstrong 24b/c, 28
-    r'(EN\d+).*[Cc]ast(\d+b?)(?:_\w+)?\.', # Endeavor 608, 617
+    r'(ar\d\d[a-c]?)(\d\d\d+[a-z]*)\.', # Armstrong 16, cast 009a
+    r'(EN\d+).*[Cc]ast(\d+[a-z]*?)(?:_\w+)?\.', # Endeavor 608, 617
     r'([Ee][Nn]\d+).*(\d{3})\.', # Endeavor
     r'(RB\d+)-(\d{3})\.', # Ron Brown
     r'(tn\d+)-(\d{3})\.', # SPIROPA testing
@@ -40,16 +41,12 @@ def pathname2cruise_cast(pathname, skip_bad_filenames=True):
                 cruise = 'ar24a'
             cruise = cruise.upper()
             # FIXME hardcoded to deal with problem with EN608 cast "13"
-            if cruise.lower() == 'en608' and cast == '13b':
-                cast = 14
+            # if cruise.lower() == 'en608' and cast == '13b':
+            #   cast = 14
             # FIXME hardcoded to deal with problem with EN627 cast "1"
             if cruise.lower() == 'en627' and cast == '1':
                 cast = 2
-            try:
-                cast = int(cast)
-            except ValueError:
-                raise ValueError('invalid cast number {}'.format(cast))
-            return cruise, cast
+            return cruise, cast      
     if not skip_bad_filenames:
         raise ValueError('unable to determine cruise and cast from "{}"'.format(pathname))
     else:

--- a/neslter/parsing/ctd/hdr.py
+++ b/neslter/parsing/ctd/hdr.py
@@ -66,7 +66,11 @@ def compile_hdr_files(hdr_dir):
         'latitude': lats,
         'longitude': lons
     }).dropna()
-    df['cast'] = df['cast'].astype(int)
+    try:
+        df['cast'] = df['cast'].astype(int)
+    except ValueError:
+        df['cast'] = df['cast'].astype(str)
     df = df.sort_values('cast')
     df.index = range(len(df))
     return df
+    

--- a/neslter/workflow/ctd.py
+++ b/neslter/workflow/ctd.py
@@ -29,7 +29,10 @@ class CtdCastWorkflow(CtdWorkflow):
         if not 'times' in cast_data.columns: # no time data available
             return cast_data # this is OK
         # the following will raise IndexError if cast is not in cast metadata
-        cast_start = pd.to_datetime(md[md.cast == self.cast].iloc[0].date)
+        try:
+            cast_start = pd.to_datetime(md[md.cast == str(self.cast)].iloc[0].date)
+        except IndexError:
+            cast_start = pd.to_datetime(md[md.cast.astype('string').str.strip("0") == self.cast.strip("0")].iloc[0].date)
         timestamp = cast_start + pd.to_timedelta(cast_data['times'], unit='s')
         cast_data['date'] = timestamp
         return cast_data

--- a/nlweb/api/urls.py
+++ b/nlweb/api/urls.py
@@ -27,8 +27,8 @@ urlpatterns = [
 
     path('ctd/<cruise>/casts', views.ctd_casts, name='ctd_casts'),
 
-    path('ctd/<cruise>/cast_<int:cast>.<extension>', views.ctd_cast, name='ctd_cast'),
-    path('ctd/<cruise>/cast_<int:cast>', views.ctd_cast, name='ctd_cast_json'),
+    path('ctd/<cruise>/cast_<cast>.<extension>', views.ctd_cast, name='ctd_cast'),
+    path('ctd/<cruise>/cast_<cast>', views.ctd_cast, name='ctd_cast_json'),
 
     path('underway/<cruise>.<extension>', views.underway, name='underway'),
     path('underway/<cruise>', views.underway, name='underway_json'),

--- a/nlweb/api/views.py
+++ b/nlweb/api/views.py
@@ -33,6 +33,7 @@ def dataframe_response(df, filename, extension='json'):
     if extension is None:
         extension = 'json'
     if extension == 'json':
+        df.reset_index(drop=True, inplace=True)
         return HttpResponse(df.to_json(), content_type='application/json')
     elif extension == 'csv':
         sio = StringIO()
@@ -95,7 +96,7 @@ def ctd_casts(request, cruise):
         md = wf.get_product()
     except KeyError:
         raise Http404()
-    casts = [int(i) for i in sorted(md['cast'].unique())]
+    casts = [str(i) for i in sorted(md['cast'].unique())]
     return JsonResponse({'casts': casts})
 
 def ctd_metadata(request, cruise, extension=None):


### PR DESCRIPTION
This fix allows for alphanumeric casts, as well as numeric casts. 

Fixes issues #56 and partially fixes issue #40. The casts and bottles endpoints will fail for cruise AR16 until a solution is found for the column issue.