### PR TITLE
Switch to generic compose configured with .env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN python setup.py install
 # now copy the django app
 COPY ./nlweb ./nlweb
 
-# configure the neslter library
-COPY config.py .
-
 EXPOSE 8000
 
 CMD gunicorn --chdir nlweb --bind :8000 nlweb.wsgi:application --reload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ services:
       - NGINX_HTTPS_PORT=${HTTPS_PORT}
     volumes:
       - ./nginx_templates:/etc/nginx/templates
-#      - ${NGINX_LOG_DIR}:/var/log/nginx
-      - ./nginx_logs:/var/log/nginx
+      - ${NGINX_LOG_DIR}:/var/log/nginx
       - ${SSL_KEY}:/ssl/ssl.key:ro
       - ${SSL_CERT}:/ssl/ssl.cer:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - DATA_ROOT=/data
     volumes:
       - ${DATA_ROOT}:/data
+      - ${LOCAL_SETTINGS}:/neslter/nlweb/nlweb/local_settings.py
     networks:
       - nginx_network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,34 @@
 version: '3'
 
 services:
-  nlweb:
+  neslter:
     build: .
     container_name: neslter
+    environment:
+      - DATA_ROOT=/data
     volumes:
-      - ./data:/data
+      - ${DATA_ROOT}:/data
     networks:
       - nginx_network
 
   nginx:
     image: nginx:latest
     container_name: nginx
-    ports:
-      - 80:80
-      - 443:443
+    environment:
+      - NGINX_HOST=${HOST}
+      - NGINX_HTTP_PORT=${HTTP_PORT}
+      - NGINX_HTTPS_PORT=${HTTPS_PORT}
     volumes:
-      - ./certs:/etc/certs
-      - ./nginx:/etc/nginx/conf.d
+      - ./nginx_templates:/etc/nginx/templates
+#      - ${NGINX_LOG_DIR}:/var/log/nginx
+      - ./nginx_logs:/var/log/nginx
+      - ${SSL_KEY}:/ssl/ssl.key:ro
+      - ${SSL_CERT}:/ssl/ssl.cer:ro
+    ports:
+      - ${HTTP_PORT}:${HTTP_PORT}
+      - ${HTTPS_PORT}:${HTTPS_PORT}
     depends_on:
-      - nlweb
+      - neslter
     networks:
       - nginx_network
 

--- a/dotenv.template
+++ b/dotenv.template
@@ -8,3 +8,5 @@ SSL_CERT=./ssl_temp/cert.pem
 SSL_KEY=./ssl_temp/key.pem
 
 NGINX_LOG_DIR=./nginx_logs
+
+LOCAL_SETTINGS=local_settings.py.template

--- a/dotenv.template
+++ b/dotenv.template
@@ -1,0 +1,10 @@
+DATA_ROOT=./data 
+
+HTTP_PORT=80
+HTTPS_PORT=443
+HOST=localhost
+
+SSL_CERT=./ssl_temp/cert.pem
+SSL_KEY=./ssl_temp/key.pem
+
+NGINX_LOG_DIR=./nginx_logs

--- a/dotenv.template
+++ b/dotenv.template
@@ -9,4 +9,4 @@ SSL_KEY=./ssl_temp/key.pem
 
 NGINX_LOG_DIR=./nginx_logs
 
-LOCAL_SETTINGS=local_settings.py.template
+LOCAL_SETTINGS=./local_settings.py.template

--- a/local_settings.py.template
+++ b/local_settings.py.template
@@ -1,0 +1,5 @@
+DEBUG = False
+
+ALLOWED_HOSTS = ['localhost']
+
+SECRET_KEY = 'replace_me_with_a_secret_key'

--- a/neslter/parsing/files.py
+++ b/neslter/parsing/files.py
@@ -1,7 +1,8 @@
 import os
 from .utils import safe_makedirs
 
-from config import DATA_ROOT
+
+DATA_ROOT=os.environ.get('DATA_ROOT', '/data')
 
 RAW = 'raw'
 PRODUCTS = 'products'

--- a/nginx_templates/default.conf.template
+++ b/nginx_templates/default.conf.template
@@ -1,0 +1,30 @@
+upstream neslter_server {
+    server neslter:8000;
+}
+
+server {
+    listen ${NGINX_HTTP_PORT};
+    listen [::]:${NGINX_HTTP_PORT};
+    server_name ${NGINX_HOST};
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen ${NGINX_HTTPS_PORT} ssl;
+    server_name ${NGINX_HOST};
+
+    ssl_certificate /ssl/ssl.cer;
+    ssl_certificate_key /ssl/ssl.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+        proxy_set_header X-Forwarder-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_pass http://neslter_server;
+    }
+}

--- a/nlweb/api/views.py
+++ b/nlweb/api/views.py
@@ -10,7 +10,7 @@ from django.views import View
 
 import pandas as pd
 
-from config import DATA_ROOT
+DATA_ROOT=os.environ.get('DATA_ROOT', '/data')
 
 from neslter.parsing.files import Resolver, DataNotFound
 

--- a/nlweb/nlweb/settings.py
+++ b/nlweb/nlweb/settings.py
@@ -118,3 +118,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+try:
+    from .local_settings import *
+except ImportError:
+    raise


### PR DESCRIPTION
Changes necessary to provide a docker-compose file that will not need to be modified for each deployment, but will instead be configured in `.env`