### PR TITLE
fixes alphanumberic cast merging chl with bottle

### DIFF
--- a/neslter/parsing/chl.py
+++ b/neslter/parsing/chl.py
@@ -72,9 +72,9 @@ def subset_chl(parsed_chl):
 def merge_bottle_summary(chl, bottle_summary):
     chl = chl.copy()
     bottle_summary = bottle_summary.copy()
-    chl.cast = chl.cast.astype(int)
+    chl.cast = chl.cast.astype(str)
     chl.niskin = chl.niskin.astype(int)
-    bottle_summary.cast = bottle_summary.cast.astype(int)
+    bottle_summary.cast = bottle_summary.cast.astype(str).str.strip("0")  #remove leading 0s for merge
     bottle_summary.niskin = bottle_summary.niskin.astype(int)
     return chl.merge(bottle_summary, on=['cruise','cast','niskin'], how='left')
 


### PR DESCRIPTION
Casts are alphnaumeric and no longer integer. Change the `cast ` from integer to string. The API was failing for the chloropyll endpoint for ar24b, en608, and ar34a cruises.

Test the api as follows:
api/chl/ar24b.csv
api/chl/en608.csv
api/chl/ar34a.csv

fixes #81 