### PR TITLE
process all cruises regardless of elog existence

### DIFF
--- a/neslter/parsing/elog.py
+++ b/neslter/parsing/elog.py
@@ -11,6 +11,8 @@ from neslter.parsing.files import Resolver
 from neslter.parsing.ctd.hdr import compile_hdr_files
 from neslter.parsing.underway import Underway
 
+from neslter.parsing.files import DataNotFound
+
 # keys
 
 INSTRUMENT = 'Instrument'
@@ -45,7 +47,8 @@ COLUMNS_WO_MESSAGE_ID = [DATETIME, INSTRUMENT, ACTION, STATION, CAST, LAT, LON, 
 def elog_path(cruise):
     elog_dir = Resolver().raw_directory('elog', cruise)
     candidates = glob(os.path.join(elog_dir, 'R2R_ELOG_*_FINAL_EVENTLOG*.csv'))
-    assert len(candidates) == 1, 'cannot find event log at {}'.format(elog_dir)
+    if len(candidates) != 1:
+         raise DataNotFound ('cannot find event log at {}'.format(elog_dir))
     return candidates[0]
 
 def hdr_path(cruise):

--- a/nlweb/api/views.py
+++ b/nlweb/api/views.py
@@ -80,9 +80,9 @@ def cruise_metadata(request):
             elog = EventLogWorkflow(cruise).get_product()
             start_date = elog[elog['Action'] == 'startCruise'].iloc[0]['dateTime8601']
             end_date = elog[elog['Action'] == 'endCruise'].iloc[0]['dateTime8601']
-        except KeyError:  # no elog for this cruise
+        except DataNotFound: # no elog or elog dir 
             pass
-        except ValueError:  # error procssing elog
+        except ValueError:  # error processing elog
             pass
         rows.append({
             'cruise': cruise,


### PR DESCRIPTION
fixes #85.

Changes: Raise DataNotFound error instead of assertion to continue processing cruises in the loop.

To Test: Run https://nes-lter-data.whoi.edu/api/cruises/metadata.csv and verify that all cruises are processed, even though some elogs may be missing for some cruises.