### PR TITLE
fix hplc datetime

### DIFF
--- a/neslter/parsing/hplc.py
+++ b/neslter/parsing/hplc.py
@@ -145,6 +145,10 @@ def parse_report(report_path):
         T: str
     })
 
+    # report file contains invalid time fields, ie 6:40:00 AM, instead of 06:40
+    # minutes must be padded with a leading zero before passed to pd.to_datetime
+    report[T] = report[T].str.split(':', n=2).str[:2].str.join(':')
+    report[T] = report[T].str.zfill(5)
     # parse date fields
     dates = report[M] + ' ' + report[D] + ' ' + report[Y] + ' ' + report[T]
     report['date'] = pd.to_datetime(dates, utc=True)
@@ -155,9 +159,9 @@ def parse_report(report_path):
     for c in report.columns:
         if c not in mappings:
             report.pop(c)
-
+    
     report.columns = [ mappings[c] for c in report.columns ]
-
+    
     # produce replicate column
     report.sort_values(['cruise','cast','niskin'], inplace=True)
 
@@ -179,7 +183,7 @@ def parse_report(report_path):
     report['comments'] = report.pop('comments') + ' ' \
         + report.pop('comments2') + ' ' + report.pop('comments3')
     report['comments'] = report['comments'].str.strip()
-
+ 
     return report
 
 def parse_hplc(hplc_dir):


### PR DESCRIPTION
fixes #90.

Fix removes seconds and AM/PM from time data read in from Sosik08-15report.xlsx. It then adds a leading zero to time data that only has 1 digit for the hour.

To test: http://localhost:8000/api/hplc/ar28b on ar28b or on any of the cruises listed in /data/raw/all/hplc/Sosik08-15report.xlsx to get data populated in the csv file.

Run testapi and observe that the hplc endpoint is returning 200 instead of 500 status code.