### PR TITLE
strip only leading zeros from cast

### DIFF
--- a/neslter/parsing/chl.py
+++ b/neslter/parsing/chl.py
@@ -74,7 +74,7 @@ def merge_bottle_summary(chl, bottle_summary):
     bottle_summary = bottle_summary.copy()
     chl.cast = chl.cast.astype(str)
     chl.niskin = chl.niskin.astype(int)
-    bottle_summary.cast = bottle_summary.cast.astype(str).str.strip("0")  #remove leading 0s for merge
+    bottle_summary.cast = bottle_summary.cast.astype(str).str.lstrip("0")  #remove leading 0s for merge
     bottle_summary.niskin = bottle_summary.niskin.astype(int)
     return chl.merge(bottle_summary, on=['cruise','cast','niskin'], how='left')
 


### PR DESCRIPTION
fixes #92 

The problem is that casts like 10, 20, and 30 were missing lat,lon,datetime, and depth data for the Chl endpoint. This is because trailing zeros were removed from the casts when they shouldn't be.

In `merge_bottle_summary`, change:
bottle_summary.cast = bottle_summary.cast.astype(str).str.**strip("0")**

to:
bottle_summary.cast = bottle_summary.cast.astype(str).str.**lstrip("0")**