### PR TITLE
fix nut api metadata dir not found for at46 & ar61b

### DIFF
--- a/neslter/workflow/stations.py
+++ b/neslter/workflow/stations.py
@@ -2,6 +2,7 @@ from neslter.parsing.stations import Stations, StationLocator
 from .api import Workflow
 
 from neslter.parsing.files import Resolver
+from neslter.parsing.files import DataNotFound
 
 METADATA = 'metadata'
 
@@ -21,7 +22,7 @@ def add_nearest_station(cruise, product, require=False):
         smd = st_wf.get_product()
         station_locator = StationLocator(smd)
         return station_locator.cast_to_station(product)
-    except KeyError:
+    except DataNotFound:
         # no station metadata. That's OK
         if require:
             raise


### PR DESCRIPTION
fixes #95 

In neslter/parsing/files.py, KeyError was changed to DataNotFound error, but in `add_nearest_station` in neslter/workflow/stations.py the KeyError check for Station Metadata was not changed to DataNotFound.

Changed KeyError to DataNotFound in `add_nearest_station`.

To test: 
https://nes-lter-data.whoi.edu/api/nut/at46 and verify data is returned.
https://nes-lter-data.whoi.edu/api/nut/ar61b and verify data is returned.