### PR TITLE
accommodate "_u" suffix in .asc filename

### DIFF
--- a/neslter/parsing/ctd/common.py
+++ b/neslter/parsing/ctd/common.py
@@ -5,6 +5,9 @@ import glob as glob
 import pandas as pd
 import numpy as np
 
+CRUISE_IDX = 1
+CAST_IDX = 2
+
 def parse_lat_lon(ll):
     """convert deg/dec minutes into dec"""
     REGEX = r'(\d+)[^\d]+([\d.]+)[^NSEW]*([NSEW])'
@@ -24,7 +27,7 @@ CRUISE_CAST_PATHNAME_REGEXES = [
     r'(ar\d\d[a-c]?)(\d\d\d)\.', # Armstrong 24b/c, 28
     r'(ar\d\d[a-c]?)(\d\d\d+[a-z]*)\.', # Armstrong 16, cast 009a
     r'(EN\d+).*[Cc]ast(\d+[a-z]*?)(?:_\w+)?\.', # Endeavor 608, 617
-    r'([Ee][Nn]\d+).*(\d{3})\.', # Endeavor
+    r'([Ee][Nn]\d+).*(\d{3})(_u)?\.', # Endeavor, EN627_028_u.asc
     r'(RB\d+)-(\d{3})\.', # Ron Brown
     r'(tn\d+)-(\d{3})\.', # SPIROPA testing
     r'(at\d+)_(\d{3})\.', # Atlantis
@@ -35,7 +38,8 @@ def pathname2cruise_cast(pathname, skip_bad_filenames=True):
     for regex in CRUISE_CAST_PATHNAME_REGEXES:
         m = re.match(regex, fn)
         if m is not None:
-            cruise, cast = m.groups()
+            cruise = m.group(CRUISE_IDX)
+            cast = m.group(CAST_IDX)
             # handle issue with old filenames for ar24a
             if cruise == 'ar24':
                 cruise = 'ar24a'


### PR DESCRIPTION
fixes #94 

Add the group "_u" to `CRUISE_CAST_PATHNAME_REGEXES` for Endeavor cruises in neslter/parsing/ctd/common.py.

`CRUISE_CAST_PATHNAME_REGEXES` now has 3 groups instead of 2. Modify the way the cruise and cast are obtained from `m.group`, using the cruise and cast index.

To test in local environment:
Rename raw data file, en627_028.asc -> en627_028_u.asc and rebuild API.
http://localhost:8000/api/ctd/en627/cast_28 and verify that data is returned from the API.

Run testapi and verify that all endpoints are working as expected.

Note: This change assumes the filename with the "_u" suffix replaces the filename without the suffix, and that the "_u" suffix filename is NOT added in addition to the filename without the suffix.