### PR TITLE
nutrient output na metadata when no bottle file

### DIFF
--- a/neslter/parsing/stations.py
+++ b/neslter/parsing/stations.py
@@ -95,10 +95,15 @@ class StationLocator(object):
         index = []
         for point in df.itertuples():
             index.append(point.Index)
-            distances = self.station_distances(getattr(point, lat_col), getattr(point, lon_col))
-            min_distance = distances.min()
-            nearest.append(self.station_metadata.loc[distances.idxmin()]['name'])
-            distance.append(min_distance)
+            # lat, lon can be NA when there is no bottle file
+            if getattr(point, lat_col) != 'NA':
+                distances = self.station_distances(getattr(point, lat_col), getattr(point, lon_col))
+                min_distance = distances.min()
+                nearest.append(self.station_metadata.loc[distances.idxmin()]['name'])
+                distance.append(min_distance)
+            else:
+                nearest.append('NA')
+                distance.append('NA')
         return pd.DataFrame({
             'nearest_station': nearest,
             'distance_km': distance,


### PR DESCRIPTION
fixes #97 #20 

We want to retain content for those columns that derive from LTERnut.xls or LTER_sample_log.xlsx 'raw' spreadsheets even if there is no bottle file for a particular cast. We will do a merge (right) of the bottle summary for the cruise with LTER_sample_log.xlsx to pick up the casts that have no bottle files. We will then do a merge of the result with LTERnut.xls. If there is no bottle file for a cast, then the lat, lon, date and depth will be set to NA for that cast in the merged data. Rows will be dropped that were picked up in btl_sum.merge right if those casts are not in btl_sum.

`nearest_station` was modified to handle NA lat, lon values in the list of points. The nearest station and distance is set to NA for the lat, lon equal to NA.

Test: run `api/nut/ar24a.csv` which does not have bottle files for Casts 1,7, and 9. Cast 1 is found in LTER_sample_log.xlsx. Verify that the lat, lon, date, depth, nearest station and distance are set to NA for Cast 1 in the nut csv file.