### PR TITLE
locating station list Excel file succeeds when it shouldn't for case-insensitive filesystems

### DIFF
--- a/neslter/parsing/stations.py
+++ b/neslter/parsing/stations.py
@@ -17,7 +17,10 @@ class Stations(object):
         resolv = Resolver()
         raw_filename = '{}_station_list.xlsx'.format(cruise.upper())
         path = resolv.raw_file(METADATA, raw_filename, cruise=cruise)
-        if not os.path.exists(path):
+        raw_dir = resolv.raw_directory(METADATA, cruise=cruise)
+        filenames = os.listdir(raw_dir)
+        # use case-sensitive string compare for case-insensitive file systems
+        if raw_filename not in filenames:
             raise KeyError('cannot find station metadata at {}'.format(path))
         self.raw_path = path
         self.cruise = cruise


### PR DESCRIPTION
fixes #53 

To perform case-sensitive comparisons in Python, even if the underlying file system is case-insensitive, compare the filenames directly without any additional transformations. Python's string comparison is case-sensitive by default. 

To test: rename /data/raw/en627/metadata/EN627_station_list.xlsx -> en627_station_list.xlsx, rebuild, and run the API station endpoint: /api/stations/en627.csv

Receive the error: 'cannot find station metadata at /data/raw/en627/metadata/EN627_station_list.xlsx'
when this test case used to pass even though the filename case does not match.

