### PR TITLE
allow sharp cruise filenames and add underway ep processing

### DIFF
--- a/neslter/parsing/ctd/common.py
+++ b/neslter/parsing/ctd/common.py
@@ -31,6 +31,7 @@ CRUISE_CAST_PATHNAME_REGEXES = [
     r'(RB\d+)-(\d{3})\.', # Ron Brown
     r'(tn\d+)-(\d{3})\.', # SPIROPA testing
     r'(at\d+)_(\d{3})\.', # Atlantis
+    r'([Hh][Rr][Ss]\d+).*(\d{3})\.', #Sharp
 ]
 
 def pathname2cruise_cast(pathname, skip_bad_filenames=True):

--- a/neslter/parsing/files.py
+++ b/neslter/parsing/files.py
@@ -78,6 +78,7 @@ def find_file(directories, filename, extension=None):
 ENDEAVOR = 'Endeavor'
 ARMSTRONG = 'Armstrong'
 ATLANTIS = 'Atlantis'
+SHARP = 'Sharp'
 
 def cruise_to_vessel(cruise):
     lower = cruise.lower()
@@ -87,5 +88,7 @@ def cruise_to_vessel(cruise):
         return ARMSTRONG
     elif lower.startswith('at'):
         return ATLANTIS
+    elif lower.startswith('hrs'):
+        return SHARP
     else:
         raise KeyError('cannot determine vessel for {}'.format(cruise))

--- a/neslter/parsing/stations.py
+++ b/neslter/parsing/stations.py
@@ -15,7 +15,10 @@ METADATA = 'metadata'
 class Stations(object):
     def __init__(self, cruise):
         resolv = Resolver()
-        raw_filename = '{}_station_list.xlsx'.format(cruise.upper())
+        if cruise.startswith('en'):
+            raw_filename = '{}_station_list.xlsx'.format(cruise.upper())
+        else:
+            raw_filename = '{}_station_list.xlsx'.format(cruise)
         path = resolv.raw_file(METADATA, raw_filename, cruise=cruise)
         if not os.path.exists(path):
             raise KeyError('cannot find station metadata at {}'.format(path))

--- a/neslter/parsing/underway.py
+++ b/neslter/parsing/underway.py
@@ -7,7 +7,7 @@ import warnings
 import pandas as pd
 import numpy as np
 
-from .files import Resolver, cruise_to_vessel, ENDEAVOR, ARMSTRONG, ATLANTIS
+from .files import Resolver, cruise_to_vessel, ENDEAVOR, ARMSTRONG, ATLANTIS, SHARP
 from .utils import data_table
 
 from neslter.parsing.ctd.hdr import HdrFile
@@ -69,7 +69,7 @@ class _ArmstrongAtlantisParser(object):
         for f in sorted(os.listdir(csv_dir)):
             if re.match(REGEX, f):
                 df = pd.read_csv(os.path.join(csv_dir, f), skiprows=1, na_values=[' NAN', ' NODATA'])
-                dfs.append(df)     
+                dfs.append(df)
         df = clean_column_names(pd.concat(dfs, ignore_index=True))
         df.insert(0, DATETIME, date_time_to_datetime(df.pop('date_gmt'), df.pop('time_gmt')))
         df.index = df[DATETIME]
@@ -80,6 +80,33 @@ class _ArmstrongAtlantisParser(object):
         if 'gps_model' in kw and kw['gps_model'] is not None:
             warnings.warn('specifying GPS model for Armstrong data has no effect')
         return 'dec_lat', 'dec_lon'
+    
+class _SharpParser(object):
+    def __init__(self, csv_dir):
+        self.df = self.parse(csv_dir)
+    def clean_sharp_column_names(self, df):
+        """clean all column names for a sharp dataframe with TWO rows as header columns"""
+        df.columns = [tuple(subcol.lower() for subcol in col) if isinstance(col, tuple) else col.lower() for col in df.columns]
+        df.columns = df.columns.map(lambda x: tuple(re.sub(r'[^a-z0-9_]+', '_', subcol) for subcol in x) if isinstance(x, tuple) else re.sub(r'[^a-z0-9_]+', '_', x))
+        # future possible column header substitutions
+        df.columns = df.columns.map(lambda x: tuple(re.sub(r'_$', '_', subcol) for subcol in x) if isinstance(x, tuple) else re.sub(r'_$', '_', x))
+        df.columns = df.columns.map(lambda x: tuple(re.sub(r'^([0-9])',r'_\1', subcol) for subcol in x) if isinstance(x, tuple) else re.sub(r'^([0-9])',r'_\1', x))
+        return df
+    def parse(self, csv_dir, resolution=60):
+        dfs = []
+        for file in sorted(os.listdir(csv_dir)):
+            if not re.match(r'HRS\d+_Data\d+Sec_\d+-\d+\.csv'.format(resolution), file):
+                continue
+            df = pd.read_csv(os.path.join(csv_dir, file), header=[0, 1], na_values=[' NAN', ' NODATA'])
+            dfs.append(df)
+        try:
+           df = pd.concat(dfs, ignore_index=True)
+        except:
+           raise ValueError('No Underway files found in {}'.format(csv_dir))
+        df = self.clean_sharp_column_names(pd.concat(dfs))
+        return df
+    def to_dataframe(self):
+        return self.df
 
 class Underway(object):
     def __init__(self, cruise, resolution=60, raw_directory=None): 
@@ -94,6 +121,8 @@ class Underway(object):
             self.parser = _EndeavorParser(csv_dir, resolution)
         elif self.vessel in [ARMSTRONG, ATLANTIS]:
             self.parser = _ArmstrongAtlantisParser(csv_dir)
+        elif self.vessel in [SHARP]:
+            self.parser = _SharpParser(csv_dir)
         self.filename = '{}_underway'.format(self.cruise)
         self.product_file = resolv.product_file(UNDERWAY, cruise, self.filename)
         self.dt = None # cached datatable


### PR DESCRIPTION
Allow for entering and processing the Underway Endpoint for Sharp Cruises, i.e. HRS2303, and add a new Class (_SharpParser) to underway.py to process Sharp Cruise Underway data.

fixes #106, #105(found bug)

For the new Sharp Cruise:
A new directory data/raw/hrs2303/underway will be created on vast.whoi.edu and the new underway data file, HRS2303_Data10Sec_200429-0000.csv, will be stored there.

Test:
api/underway/hrs2303.csv and verify a hrs2303_underway.csv file is created.