### PR TITLE
add comment to pandas read_fwf

### DIFF
--- a/neslter/parsing/ctd/asc.py
+++ b/neslter/parsing/ctd/asc.py
@@ -29,6 +29,7 @@ def parse_asc_fwf(asc_path):
     col_width = int(len(line) / n_cols)
     col_widths = [col_width for _ in range(n_cols)]
     # now parse the fixed-width format
+    # Pandas will automatically append ".1" to any duplicate column name
     df = pd.read_fwf(asc_path, widths=col_widths, encoding='latin-1')
     return df
 


### PR DESCRIPTION
# Pandas will automatically append ".1" to any duplicate column name
df = pd.read_fwf(asc_path, widths=col_widths, encoding='latin-1') 

If there are duplicate column names in the fixed-width file, Pandas will automatically handle them by appending a suffix to make them unique. So, the process of handling duplicate column names and appending ".1" is inherent in the behavior of pd.read_fwf() when it encounters duplicate names during the creation of the DataFrame. 