### PR TITLE
Quick fix: Addressing 500 in cruise metadata when cruise lacked endCruise event

### DIFF
--- a/neslter/parsing/elog.py
+++ b/neslter/parsing/elog.py
@@ -153,12 +153,15 @@ class EventLog(object):
             uw = Underway(self.cruise)
         except:
             raise
-        uw_lat = self.df[DATETIME].map(lambda t: uw.time_to_lat(t))
-        uw_lon = self.df[DATETIME].map(lambda t: uw.time_to_lon(t))
-        #self.df[LAT] = self.df[LAT].combine_first(uw_lat)
-        #self.df[LON] = self.df[LON].combine_first(uw_lon)
-        self.df[LAT] = uw_lat
-        self.df[LON] = uw_lon
+        try:
+            uw_lat = self.df[DATETIME].map(lambda t: uw.time_to_lat(t))
+            uw_lon = self.df[DATETIME].map(lambda t: uw.time_to_lon(t))
+            #self.df[LAT] = self.df[LAT].combine_first(uw_lat)
+            #self.df[LON] = self.df[LON].combine_first(uw_lon)
+            self.df[LAT] = uw_lat
+            self.df[LON] = uw_lon
+        except:
+            pass # FIXME need to address issues with Sharp underway data
     def to_dataframe(self):
         self.df.index = range(len(self.df))
         self.df = self.df.sort_values(DATETIME)

--- a/neslter/parsing/underway.py
+++ b/neslter/parsing/underway.py
@@ -97,6 +97,8 @@ class _SharpParser(object):
            raise ValueError('No Underway files found in {}'.format(csv_dir))
         df = clean_column_names(pd.concat(dfs))
         return df
+    def lat_lon_columns(self, **kw):
+        return 'latitude_deg', 'longitude_deg'
     def to_dataframe(self):
         return self.df
 

--- a/nlweb/api/views.py
+++ b/nlweb/api/views.py
@@ -74,12 +74,18 @@ def cruise_metadata(request):
     rows = []
     cruises = Resolver().cruises()
     for cruise in cruises:
-        start_date = ''
-        end_date = ''
+        start_date = 'NAN'
+        end_date = 'NAN'
         try:
             elog = EventLogWorkflow(cruise).get_product()
-            start_date = elog[elog['Action'] == 'startCruise'].iloc[0]['dateTime8601']
-            end_date = elog[elog['Action'] == 'endCruise'].iloc[0]['dateTime8601']
+            try:
+                start_date = elog[elog['Action'] == 'startCruise'].iloc[0]['dateTime8601']
+            except IndexError:
+                pass # no startCruise
+            try:
+                end_date = elog[elog['Action'] == 'endCruise'].iloc[0]['dateTime8601']
+            except IndexError:
+                pass # no endCruise
         except DataNotFound: # no elog or elog dir 
             pass
         except ValueError:  # error processing elog


### PR DESCRIPTION
This surfaced because hrs2303 lacked an endCruise event.

Other issues surfaced as well, notably the use of underway locations in the elog endpoint, which are not completely addressed for Sharp data but no longer produce errors.