### PR TITLE
fix hrs2303 underway ep

### DIFF
--- a/neslter/parsing/underway.py
+++ b/neslter/parsing/underway.py
@@ -90,7 +90,9 @@ class _SharpParser(object):
             if not re.match(r'HRS\d+_Data\d+Sec_\d+-\d+\.csv'.format(resolution), file):
                 continue
             df = pd.read_csv(os.path.join(csv_dir, file), header=[0], 
-                             na_values=[' NAN', ' NODATA'] , na_rep='NaN') #set numeric missing values to 'NaN'
+                             na_values=[' NAN', ' NODATA'])
+            if 'date' in df.columns:
+                df['date'] = df['date'].fillna('')
             dfs.append(df)
         try:
            df = pd.concat(dfs, ignore_index=True)


### PR DESCRIPTION
Fixes the HRS2303 Underway EP:

1. The error: read_csv() got an unexpected keyword argument 'na_rep' underway.py on the line: `df = pd.read_csv(os.path.join(csv_dir, file), header=[0], na_values=[' NAN', ' NODATA'] , na_rep='NaN')`

2. Sets the 'date' column NaN values to the empty string per issue #116 .