### PR TITLE
empty nut date should be the empty string

### DIFF
--- a/neslter/parsing/nut/nut.py
+++ b/neslter/parsing/nut/nut.py
@@ -103,7 +103,7 @@ def merge_nut_bottles(sample_log_path, nut_path, bottle_summary, cruise):
             if cast is None:
                  continue
             cast = cast.lstrip('0')
-            nut_profile.loc[nut_profile['cast'] == cast, 'date'] = 'NA'
+            nut_profile.loc[nut_profile['cast'] == cast, 'date'] = ''
             nut_profile.loc[nut_profile['cast'] == cast, 'latitude'] = 'NA'
             nut_profile.loc[nut_profile['cast'] == cast, 'longitude'] = 'NA'
             nut_profile.loc[nut_profile['cast'] == cast, 'depth'] = 'NA'


### PR DESCRIPTION
Fixes #116.

The nutrient ep, /api/nut, is setting the empty date string to NA when it should be the empty string. 

Also, this fixes generating the Nutrient Transect package. The Rmd file in the Nutrient Transect package is looking for the empty string to exclude rows of data, but NA rows of data are included when they should not be.