### PR TITLE
change nut lat check from 'NA' to NaN

### DIFF
--- a/neslter/parsing/nut/nut.py
+++ b/neslter/parsing/nut/nut.py
@@ -94,7 +94,7 @@ def merge_nut_bottles(sample_log_path, nut_path, bottle_summary, cruise):
     nut_profile['cast'] = nut_profile['cast'].astype(str)
     nut_profile['alternate_sample_id'] = nut_profile.pop('ooi_nut_id')
 
-    # set date, lat, lon, depth to NA when there is no bottle file for the cast
+    # set date, lat, lon, depth to NaN when there is no bottle file for the cast
     btl_dir = Resolver().raw_directory('ctd', cruise)
     for file in sorted(glob(os.path.join(btl_dir, '*.asc'))):
         if cruise == 'en627':
@@ -106,9 +106,9 @@ def merge_nut_bottles(sample_log_path, nut_path, bottle_summary, cruise):
                  continue
             cast = cast.lstrip('0')
             nut_profile.loc[nut_profile['cast'] == cast, 'date'] = ''
-            nut_profile.loc[nut_profile['cast'] == cast, 'latitude'] = 'NA'
-            nut_profile.loc[nut_profile['cast'] == cast, 'longitude'] = 'NA'
-            nut_profile.loc[nut_profile['cast'] == cast, 'depth'] = 'NA'
+            nut_profile.loc[nut_profile['cast'] == cast, 'latitude'] = 'NaN'
+            nut_profile.loc[nut_profile['cast'] == cast, 'longitude'] = 'NaN'
+            nut_profile.loc[nut_profile['cast'] == cast, 'depth'] = 'NaN'
 
     # drop rows (picked up in btl_sum.merge right) with casts that were not in btl_sum
     nut_profile.dropna(subset=['date'], inplace=True)

--- a/neslter/parsing/stations.py
+++ b/neslter/parsing/stations.py
@@ -98,8 +98,8 @@ class StationLocator(object):
         index = []
         for point in df.itertuples():
             index.append(point.Index)
-            # lat, lon can be NA when there is no bottle file
-            if getattr(point, lat_col) != 'NA':
+            # lat, lon can be NaN when there is no bottle file
+            if not pd.isna(getattr(point, lat_col)):
                 distances = self.station_distances(getattr(point, lat_col), getattr(point, lon_col))
                 min_distance = distances.min()
                 if min_distance > 2:


### PR DESCRIPTION
 https://nes-lter-data.whoi.edu/api/nut/ar61a ep was throwing this error because empty lat values were changed from 'NA' to NaN:

raise ValueError('Point coordinates must be finite. %r has been passed 
neslter  | ValueError: Point coordinates must be finite. (nan, nan, 0.0) has been passed as coordinates.

Use pd.isna to check for NaN values.

