### PR TITLE
update to new way of doing setuptools install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY VERSION .
 COPY setup.py .
 
 # install neslter library
-RUN python setup.py install
+RUN pip install .
 
 # now copy the django app
 COPY ./nlweb ./nlweb


### PR DESCRIPTION
This fixes the Docker build which was using
```
python setup.py install
```
instead of
```
pip install .
```